### PR TITLE
fix boot_reason to get reboot into fastboot

### DIFF
--- a/arch/arm64/boot/dts/qcom/pm660.dtsi
+++ b/arch/arm64/boot/dts/qcom/pm660.dtsi
@@ -49,8 +49,10 @@
 		};
 
 		pon: pon@800 {
-			compatible = "qcom,pm8916-pon";
-
+			compatible = "qcom,pm8998-pon";
+                        mode-bootloader = <0x2>;
+                        mode-recovery = <0x1>;
+			
 			reg = <0x800>;
 
 			pwrkey {


### PR DESCRIPTION
To fix issue when reboot into fastboot fail. That is on par with msm8998.dtsi